### PR TITLE
Parse charlist sigil

### DIFF
--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -55,8 +55,13 @@ defmodule Xpeg.Parser do
           hi_chars = mk_set([hi]) |> Enum.flat_map(fn {:set, chars} -> chars end)
           Enum.uniq(Enum.to_list(Enum.min(lo_chars)..Enum.max(hi_chars)) ++ set)
 
-        {:sigil_c, _, [chars, _]} ->
-          # Handle ~c sigil format by converting to charlist
+        {:sigil_c, _, [{:<<>>, _, [chars]}, _]} when is_binary(chars) ->
+          # Handle ~c sigil format where chars is wrapped in a tuple
+          chars_list = to_charlist(chars)
+          Enum.uniq(chars_list ++ set)
+
+        {:sigil_c, _, [chars, _]} when is_binary(chars) ->
+          # Handle ~c sigil format where chars is directly a binary
           chars_list = to_charlist(chars)
           Enum.uniq(chars_list ++ set)
 

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -45,11 +45,32 @@ defmodule Xpeg.Parser do
   # Charset
   defp mk_set(ps) do
      cs = Enum.reduce(ps, [], fn p, set ->
-       case p do
-         [v] -> [v | set]
-         {:.., _, [[lo], [hi]]} -> Enum.uniq(Enum.to_list(lo..hi) ++ set)
-       end
-     end)
+      case p do
+        [v] ->
+          [v | set]
+
+        {:.., _, [lo, hi]} ->
+          # Recursively parse lo and hi to handle nested sigils
+          lo_chars = mk_set([lo]) |> Enum.flat_map(fn {:set, chars} -> chars end)
+          hi_chars = mk_set([hi]) |> Enum.flat_map(fn {:set, chars} -> chars end)
+          Enum.uniq(Enum.to_list(Enum.min(lo_chars)..Enum.max(hi_chars)) ++ set)
+
+        {:sigil_c, _, [chars, _]} ->
+          # Handle ~c sigil format by converting to charlist
+          chars_list = to_charlist(chars)
+          Enum.uniq(chars_list ++ set)
+
+        v when is_binary(v) ->
+          # Handle string literals directly
+          chars_list = to_charlist(v)
+          Enum.uniq(chars_list ++ set)
+
+        v when is_list(v) and length(v) == 1 ->
+          # Handle single character charlist
+          [hd(v) | set]
+      end
+    end)
+
     [{:set, cs}]
   end
 
@@ -121,7 +142,14 @@ defmodule Xpeg.Parser do
 
       # Charset
       {:{}, _, ps} ->
-        mk_set(ps)
+        # Preprocess each element in the set to handle string literals
+        processed_ps =
+          Enum.map(ps, fn
+            {:<<>>, _meta, [string]} when is_binary(string) -> string
+            other -> other
+          end)
+
+        mk_set(processed_ps)
 
       # Repetition count [low..hi]
       {{:., _, [Access, :get]}, _, [p, {:.., _, [n1, n2]}]} ->
@@ -167,6 +195,16 @@ defmodule Xpeg.Parser do
       # Charlist
       v when is_list(v) ->
         for c <- v do {:chr, c} end
+        
+      # Add support for string literals in AST format
+      {:<<>>, _meta, [string]} when is_binary(string) ->
+        {:chr, to_charlist(string)}
+
+      # Add support for sigil format
+      {:sigil_c, _meta, [chars, _]} ->
+        for c <- to_charlist(chars) do
+          {:chr, c}
+        end
             
       {_, meta, e} ->
         raise("XPeg: #{inspect(meta)}: Syntax error at '#{Macro.to_string(e)}' \n\n   #{inspect(e)}\n")

--- a/lib/railroad.ex
+++ b/lib/railroad.ex
@@ -228,7 +228,7 @@ defmodule Xpeg.Railroad do
     {ylo, yhi} = Enum.map(Map.keys(map), &elem(&1, 1)) |> Enum.min_max()
     for y <- ylo .. yhi do
       for x <- xlo .. xhi do
-        Map.get(map, {x, y}, ' ')
+        Map.get(map, {x, y}, ~c" ")
       end
       |> Enum.join("")
     end

--- a/lib/xpeg.ex
+++ b/lib/xpeg.ex
@@ -133,6 +133,15 @@ defmodule Xpeg do
   Define a grammar with one anonymous rule.
   """
   defmacro patt(v) do
+    # Convert string literals to charlists before parsing
+    v = Macro.prewalk(v, fn
+      {:<<>>, _meta, [string]} when is_binary(string) ->
+        string
+
+      other ->
+        other
+    end)
+      
     {id, ast} = make(:anon, %{anon: Xpeg.Parser.parse(v)}, [])
     quote do
       Module.create(unquote(id), unquote(ast), Macro.Env.location(__ENV__))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Xpeg.MixProject do
   def project do
     [
       app: :xpeg,
-      version: "0.9.1",
+      version: "0.10.0",
       description: "Native Elixir PEG (Parsing Expression Grammars) string matching library",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,

--- a/test/xpeg_test.exs
+++ b/test/xpeg_test.exs
@@ -21,6 +21,7 @@ defmodule XpegTest do
     run(patt("a"), "b", :error)
     run(patt("abc"), "abc")
     run(patt('abc'), "abc")
+    run(patt(~c"abc"), "abc")
     run(patt("abc"), "-bcd", :error)
     run(patt("abc"), "a-cd", :error)
     run(patt("abc"), "ab-d", :error)
@@ -61,6 +62,42 @@ defmodule XpegTest do
     run(patt({'a'..'c', 'e'..'g'}), "f")
     run(patt({'a'..'c', 'e'..'g'}), "g")
   end
+  
+  test "set using sigil" do
+    run(patt({~c"a"}), "a")
+    run(patt({~c"a"}), "a")
+    run(patt({~c"b"}), "a", :error)
+    run(patt({~c"a", ~c"b"}), "a")
+    run(patt({~c"a", ~c"b"}), "b")
+    run(patt({~c"a", ~c"b"}), "c", :error)
+    run(patt({~c"a", ~c"b", ~c"c"}), "a")
+    run(patt({~c"a", ~c"b", ~c"c"}), "b")
+    run(patt({~c"a", ~c"b", ~c"c"}), "c")
+    run(patt({~c"a", ~c"b", ~c"c"}), "d", :error)
+    run(patt({~c"a"..~c"c"}), "a")
+    run(patt({~c"a"..~c"c"}), "b")
+    run(patt({~c"a"..~c"c"}), "c")
+    run(patt({~c"a"..~c"c"}), "d", :error)
+    run(patt({~c"a"..~c"c", ~c"d"}), "a")
+    run(patt({~c"a"..~c"c", ~c"d"}), "b")
+    run(patt({~c"a"..~c"c", ~c"d"}), "c")
+    run(patt({~c"a"..~c"c", ~c"d"}), "d")
+    run(patt({~c"a", ~c"b"..~c"d"}), "a")
+    run(patt({~c"a", ~c"b"..~c"d"}), "b")
+    run(patt({~c"a", ~c"b"..~c"d"}), "c")
+    run(patt({~c"a", ~c"b"..~c"d"}), "d")
+    run(patt({~c"a", ~c"b"..~c"c", ~c"d"}), "a")
+    run(patt({~c"a", ~c"b"..~c"c", ~c"d"}), "b")
+    run(patt({~c"a", ~c"b"..~c"c", ~c"d"}), "c")
+    run(patt({~c"a", ~c"b"..~c"c", ~c"d"}), "d")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "a")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "b")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "c")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "d", :error)
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "e")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "f")
+    run(patt({~c"a"..~c"c", 'e'..~c"g"}), "g")
+  end
 
   test "zero-or-one" do
     run(patt("a" * opt("b") * "c"), "ac")
@@ -74,16 +111,34 @@ defmodule XpegTest do
     run(patt(star('a') * 'b'), "bbbbb")
     run(patt(star('a') * 'b'), "caaab", :error)
   end
+  
+  test "zero-or-more using sigils" do
+    run(patt(star(~c"a")), "aaaa")
+    run(patt(star(~c"a") * ~c"b"), "aaaab")
+    run(patt(star(~c"a") * ~c"b"), "bbbbb")
+    run(patt(star(~c"a") * ~c"b"), "caaab", :error)
+  end
 
   test "one-or-more" do
     run(patt(+'a' * 'b'), "aaaab")
     run(patt(+'a' * 'b'), "ab")
     run(patt(+'a' * 'b'), "b", :error)
   end
+  
+  test "one-or-more using sigils" do
+    run(patt(+~c"a" * ~c"b"), "aaaab")
+    run(patt(+~c"a" * ~c"b"), "ab")
+    run(patt(+~c"a" * ~c"b"), "b", :error)
+  end
 
   test "not-predicate" do
     run(patt('a' * !'b'), "ac")
     run(patt('a' * !'b'), "ab", :error)
+  end
+  
+  test "not-predicate using sigils" do
+    run(patt(~c"a" * !~c"b"), "ac")
+    run(patt(~c"a" * !~c"b"), "ab", :error)
   end
 
   test "and-predicate" do
@@ -111,6 +166,18 @@ defmodule XpegTest do
     run(patt('a'[0..1] * !1), "a")
     run(patt('a'[0..1] * !1), "aa", :error)
   end
+  
+  test "[m..n]: count using sigils" do
+    run(patt(~c"a"[2..4] * !1), "", :error)
+    run(patt(~c"a"[2..4] * !1), "a", :error)
+    run(patt(~c"a"[2..4] * !1), "aa")
+    run(patt(~c"a"[2..4] * !1), "aaa")
+    run(patt(~c"a"[2..4] * !1), "aaaa")
+    run(patt(~c"a"[2..4] * !1), "aaaaa", :error)
+    run(patt(~c"a"[0..1] * !1), "")
+    run(patt(~c"a"[0..1] * !1), "a")
+    run(patt(~c"a"[0..1] * !1), "aa", :error)
+  end
 
   test "|: ordered choice" do
     run(patt("ab" | "cd"), "ab")
@@ -128,6 +195,7 @@ defmodule XpegTest do
     run(patt("abcd" - "abcdef"), "abcdefgh", :error)
     run(patt("abcd" - "abcdf"), "abcdefgh")
     run(patt({'a','b','c'} - {'a'}), "a", :error)
+    run(patt({~c"a", ~c"b", ~c"c"} - {~c"a"}), "a", :error)
   end
 
   test "Misc combos" do
@@ -137,6 +205,15 @@ defmodule XpegTest do
     run(patt('a' | 'b' * 'c' | 'd' * 'e' * 'f'), "def")
     run(patt({'a','b'} * 'c' | {'a','b'} * 'e'), "ac")
     run(patt({'a','b'} * 'c' | {'a','b'} * 'e'), "ae")
+  end
+  
+  test "Misc combos using sigils" do
+    run(patt(~c"a" | ~c"b" * ~c"c"), "a")
+    run(patt(~c"a" | ~c"b" * ~c"c" | ~c"d" * ~c"e" * 'f'), "a")
+    run(patt(~c"a" | ~c"b" * ~c"c" | ~c"d" * ~c"e" * 'f'), "bc")
+    run(patt(~c"a" | ~c"b" * ~c"c" | ~c"d" * ~c"e" * 'f'), "def")
+    run(patt({~c"a", ~c"b"} * ~c"c" | {~c"a", ~c"b"} * ~c"e"), "ac")
+    run(patt({~c"a", ~c"b"} * ~c"c" | {~c"a", ~c"b"} * ~c"e"), "ae")
   end
   
   test "grammars" do


### PR DESCRIPTION
Fixes #8.

This PR only make changes to parse charlist sigils (`~c""`). I tried to not make any change to formatting or other unrelated changes.

If interested, I have a more complete set of changes on our master branch, which includes:

* Added the sigil parser (changes from this PR).
* Mix format on all files.
* Added the `mix.lock` file to be versioned.
* Fixed typos.
* Added a GH Actions CI workflow.

Compare changes: https://github.com/zevv/xpeg/compare/master...Tubitv:xpeg:master